### PR TITLE
feat: #226 파이어베이스와 안드로이드 연동

### DIFF
--- a/saver-android/.idea/gradle.xml
+++ b/saver-android/.idea/gradle.xml
@@ -4,7 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/saver-android/app/build.gradle
+++ b/saver-android/app/build.gradle
@@ -38,6 +38,7 @@ apply plugin: 'com.google.gms.google-services'
 dependencies {
     implementation platform('com.google.firebase:firebase-bom:28.2.1')
     implementation 'com.google.firebase:firebase-analytics-ktx'
+    implementation 'com.google.firebase:firebase-messaging-ktx'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'

--- a/saver-android/app/src/main/AndroidManifest.xml
+++ b/saver-android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/saver-android/app/src/main/java/com/seoul42/saver_android/MainActivity.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/MainActivity.kt
@@ -3,12 +3,15 @@ package com.seoul42.saver_android
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.ktx.messaging
 
 class MainActivity : AppCompatActivity() {
 
-   private val myWebView: WebView by lazy{
+    private val myWebView: WebView by lazy {
         findViewById(R.id.main_webView)
     }
 
@@ -21,19 +24,44 @@ class MainActivity : AppCompatActivity() {
 
         myWebView.apply {
             webViewClient = WebViewClient()
-            settings.domStorageEnabled =true
+            settings.domStorageEnabled = true
             settings.javaScriptEnabled = true
         }
+
         myWebView.loadUrl("https://thesaver.io")
     }
 
     override fun onBackPressed() {
         if (myWebView.canGoBack()) {
             myWebView.goBack()
-        }
-        else {
+        } else {
             finish()
         }
+    }
+
+    private fun subscribeTopic(topic: String) {
+        Firebase.messaging.subscribeToTopic(topic)
+            .addOnCompleteListener { task ->
+                var msg = ""
+                msg = if (task.isSuccessful)
+                    "성공"
+                else
+                    "실패"
+                Log.d("구독", msg)
+            }
+
+    }
+
+    private fun unsubscribeTopic(topic: String) {
+        Firebase.messaging.unsubscribeFromTopic(topic)
+            .addOnCompleteListener { task ->
+                var msg = "성공"
+                if (!task.isSuccessful) {
+                    msg = "실패"
+                }
+                Log.d("구독 취소", msg)
+            }
+
     }
 
 }

--- a/saver-android/app/src/main/java/com/seoul42/saver_android/MyFirebaseMessagingService.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/MyFirebaseMessagingService.kt
@@ -1,0 +1,13 @@
+package com.seoul42.saver_android
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MyFirebaseMessagingService(): FirebaseMessagingService() {
+    override fun onMessageReceived(p0: RemoteMessage) {
+        super.onMessageReceived(p0)
+        Log.d("firebase", "메세지 수신 성공!")
+    }
+
+}


### PR DESCRIPTION
# 개요
- 파이어베이스와 안드로이드 연동
- 구독 후 해당 토픽으로 메세지를 보내면 onMessageReceived에서 응답

# 작업사항


## 메인화면



# 참고사항
동작 확인은 [send](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send?hl=ko)에서
parent에 google-services.json->project_info->project_id 값을 **project/project_id** 형태로 넣고 
body 에 `{ "message": { "topic": 구독한 topic } }` 형태로 넣은 뒤에 
execute하면 파이어베이스를 통해 메세지가 보내집니다. 

테스트 하려면 mainActivity가 시작될 때 원하는 토픽으로 값을 넣어 subscribeTopic을 실행시켜주어야 합니다. 
로그에 '메세지 수신 성공'이 뜨면 연동이 완료된 것입니다.

참고자료: [Android에서 Firebase 클라우드 메시징 클라이언트 앱 설정](https://firebase.google.com/docs/cloud-messaging/android/client?hl=ko)
