### PR TITLE
feat: #255 안드로이드 공유하기 앱으로 연결

### DIFF
--- a/saver-android/.idea/runConfigurations.xml
+++ b/saver-android/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/saver-android/app/src/main/AndroidManifest.xml
+++ b/saver-android/app/src/main/AndroidManifest.xml
@@ -4,13 +4,18 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <queries>
+        <package android:name="com.kakao.talk" />
+    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Saverandroid">
+        android:theme="@style/Theme.Saverandroid"
+        android:usesCleartextTraffic="true">
         <meta-data
             android:name="com.google.android.actions"
             android:resource="@xml/splash" />
@@ -34,6 +39,16 @@
                     android:host="thesaver.io"
                     android:scheme="https" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                   <data
+                    android:host="kakaolink"
+                    android:scheme="@string/key" />
+            </intent-filter>
+
         </activity>
 
         <service

--- a/saver-android/app/src/main/java/com/seoul42/saver_android/MainActivity.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/MainActivity.kt
@@ -1,12 +1,10 @@
 package com.seoul42.saver_android
 
 import android.content.Intent
-import android.net.Uri
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.webkit.WebView
-import android.webkit.WebViewClient
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.messaging.ktx.messaging
@@ -16,36 +14,45 @@ class MainActivity : AppCompatActivity() {
     private val myWebView: WebView by lazy {
         findViewById(R.id.main_webView)
     }
-    private val swipeRefreshLayout: SwipeRefreshLayout by lazy{
+    private val swipeRefreshLayout: SwipeRefreshLayout by lazy {
         findViewById(R.id.swipe_refresh_layout)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        val data: Uri? = intent?.data
-        var url: String? = intent.getStringExtra("url")
-        if (data != null)
-            url = data.toString()
 
-
-        var intent = Intent(this, SplashScreenActivity::class.java)
-        startActivity(intent)
+        startActivity(Intent(this, SplashScreenActivity::class.java))
 
         myWebView.apply {
-            webViewClient = WebViewClient()
-            settings.domStorageEnabled = true
-            settings.javaScriptEnabled = true
-        }
-        myWebView.loadUrl("https://thesaver.io")
-        url?.let {
-            myWebView.loadUrl(url)
+            settings.run {
+                javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                javaScriptCanOpenWindowsAutomatically = true
+                setSupportMultipleWindows(true)
+            }
+            loadUrl(getStartUrl(intent))
         }
 
         swipeRefreshLayout.setOnRefreshListener {
             myWebView.reload()
             swipeRefreshLayout.isRefreshing = false
         }
+    }
+
+    private fun getStartUrl(intent: Intent): String {
+        val baseUrl = "https://thesaver.io/";
+        var url: String? = intent.getStringExtra("url")
+        if (intent?.data != null)
+            url = intent?.data.toString()
+        url?.let {
+            if (it.contains("kakaolink")) {
+                Log.d("주소", baseUrl + "${it.substring(it.indexOf('?') + 1, it.length)}");
+                return baseUrl + "${it.substring(it.indexOf('?') + 1, it.length)}"
+            }
+            return url
+        }
+        return baseUrl
     }
 
     override fun onBackPressed() {

--- a/saver-android/app/src/main/res/values/strings.xml
+++ b/saver-android/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">saver-android</string>
+    <string name="key">kakao{카카오 네이티브 키}</string>
+
 </resources>


### PR DESCRIPTION
# 개요
- 공유받은 링크에서 앱으로 보기를 누르면 앱으로 연결되도록 구현

# 작업사항

## 메인화면



# 참고사항
- res/values/strings.xml에 key를 **kakao{카카오 네이티브 키}** 형태의 값으로 설정해주어야합니다.  
(ex: kakao1234abcd)
- 실행중인 웹으로 연결할 경우 MainActivity의 주소를 바꿔야합니다.
-  localhost로 하면 인식을 못하므로 주소를 baseUrl을 http://localhost:1234 대신  http://ip주소:1234 로 지정해주세요. (ex: http://192.168.0.5:1234)
- 카카오 플랫폼 사이트에 해당 주소를 추가해야 정상적으로 작동됩니다.

