### PR TITLE
feat: #276 안드로이드 화면 세로고정

### DIFF
--- a/saver-android/app/src/main/AndroidManifest.xml
+++ b/saver-android/app/src/main/AndroidManifest.xml
@@ -23,9 +23,11 @@
         <activity
             android:name=".SplashScreenActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
+            android:screenOrientation="portrait"
             android:exported="true" />
         <activity android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
+            android:screenOrientation="portrait"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION

# 개요
-앱 화면을 세로로 고정

# 작업사항
-manifest 파일의 액티비티 속성에 android:screenOrientation="portrait" 추가
 
## 메인화면



# 참고사항
