### PR TITLE
fix: #286 articles/detail 버튼 위치 수정

### DIFF
--- a/saver-web/views/user/article.ejs
+++ b/saver-web/views/user/article.ejs
@@ -24,6 +24,7 @@
   <p class="article__main-text ft-main">
   </p>
   <div class="article__control">
+    <div></div>
     <div id="share-modal-1" class="share-modal">
       <div class="modal-content">
         <div class="title">


### PR DESCRIPTION
# 개요
- 버튼 위치가 오른쪽으로 가도록 수정

# 작업사항
- `<div class="article__control">` 바로 밑에  `<div></div>` 추가


## 메인화면



# 참고사항
- [참고자료](https://www.daleseo.com/css-align-right/)