### PR TITLE
fix: 볼드체가 정렬되지 않는 버그 수정

### DIFF
--- a/saver-web/public/stylesheets/user/reset.css
+++ b/saver-web/public/stylesheets/user/reset.css
@@ -92,8 +92,6 @@ video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
-  vertical-align: -webkit-baseline-middle;
-  vertical-align: -moz-middle-with-baseline;
   text-decoration: none;
   color: inherit;
 }


### PR DESCRIPTION

# 개요
-볼드체가 반정도 아래 보이는 현상 수정

# 작업사항
-reset.css 에서 webkit-baseline-middle, -moz-middle-with-baseline 삭제

## 메인화면



# 참고사항
-찾아보니 webkit-baseline-middle 는 Chrome에서만 사용할 수 있고 -moz-middle-with-baseline 는 Firefox에서 사용할 수 있는 속성이라고 합니다. 둘 모두 표준에 없는 부분이라 버그가 발생한 것 같습니다.