### PR TITLE
fix: #301 카카오톡 공유 시 html 태그 노출 오류 수정

### DIFF
--- a/saver-web/public/javascripts/sharetotal.js
+++ b/saver-web/public/javascripts/sharetotal.js
@@ -47,7 +47,7 @@ function KaKaoShare  (id, article)  {
             targetLink += `articles/detail/${article.id}`;
         }
 
-        const briefing = unescape(article.briefing);
+        const briefing = removeTag(unescape(article.briefing));
 
         Kakao.Link.createDefaultButton({
         container: `#${id}`,

--- a/saver-web/public/javascripts/sharetotal.js
+++ b/saver-web/public/javascripts/sharetotal.js
@@ -33,6 +33,12 @@ function urlshare(url){
     alert('url 복사가 완료되었습니다.');
 }
 
+//html 태그 제거
+function removeTag(text) {
+    text = text.replace(/(<([^>]+)>)/ig, "");
+    return text;
+}
+
 function KaKaoShare  (id, article)  {
     try{
         if (!Kakao.isInitialized()) Kakao.init('카카오 JS 키');
@@ -41,12 +47,14 @@ function KaKaoShare  (id, article)  {
             targetLink += `articles/detail/${article.id}`;
         }
 
+        const briefing = unescape(article.briefing);
+
         Kakao.Link.createDefaultButton({
         container: `#${id}`,
         objectType: 'feed',
         content: {
             title: article.headline,
-            description: unescape(article.briefing),
+            description: briefing,
             imageUrl: article.image,
             link: {
             webUrl: targetLink,


### PR DESCRIPTION

# 개요
- 카카오톡 공유 했을 때 본문에 html태그가 노출되는 오류.

# 작업사항
- 정규식을 이용해 description부분의 html 태그를 삭제했습니다.