### PR TITLE
feat : 안드로이드에서 페이스북 공유시 페이스북 앱이 열리도록 설정

### DIFF
--- a/saver-android/app/build.gradle
+++ b/saver-android/app/build.gradle
@@ -36,6 +36,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 dependencies {
+    implementation 'com.facebook.android:facebook-share:[8,9)'
     implementation platform('com.google.firebase:firebase-bom:28.2.1')
     implementation 'com.google.firebase:firebase-analytics-ktx'
     implementation 'com.google.firebase:firebase-messaging-ktx'

--- a/saver-android/app/src/main/AndroidManifest.xml
+++ b/saver-android/app/src/main/AndroidManifest.xml
@@ -16,10 +16,14 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Saverandroid"
         android:usesCleartextTraffic="true">
+        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_key"/>
+        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
         <meta-data
             android:name="com.google.android.actions"
             android:resource="@xml/splash" />
-
+        <provider android:authorities="com.facebook.app.FacebookContentProvider{페이스북 APP_ID}"
+            android:name="com.facebook.FacebookContentProvider"
+            android:exported="true"/>
         <activity
             android:name=".SplashScreenActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"

--- a/saver-android/app/src/main/AndroidManifest.xml
+++ b/saver-android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,9 @@
     <queries>
         <package android:name="com.kakao.talk" />
     </queries>
+    <queries>
+        <provider android:authorities="com.facebook.katana.provider.PlatformProvider" />
+    </queries>
 
     <application
         android:allowBackup="true"
@@ -16,23 +19,30 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Saverandroid"
         android:usesCleartextTraffic="true">
-        <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_key"/>
-        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
+        <meta-data
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_key" />
+        <meta-data
+            android:name="com.facebook.sdk.ClientToken"
+            android:value="@string/facebook_client_token" />
         <meta-data
             android:name="com.google.android.actions"
             android:resource="@xml/splash" />
-        <provider android:authorities="com.facebook.app.FacebookContentProvider{페이스북 APP_ID}"
+
+        <provider
             android:name="com.facebook.FacebookContentProvider"
-            android:exported="true"/>
+            android:authorities="com.facebook.app.FacebookContentProvider{페이스북 APP ID}"
+            android:exported="true" />
+
         <activity
             android:name=".SplashScreenActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:screenOrientation="portrait"
-            android:exported="true" />
-        <activity android:name=".MainActivity"
+            android:exported="true"
+            android:screenOrientation="portrait" />
+        <activity
+            android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:screenOrientation="portrait"
-            >
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -53,7 +63,8 @@
 
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                   <data
+
+                <data
                     android:host="kakaolink"
                     android:scheme="@string/key" />
             </intent-filter>

--- a/saver-android/app/src/main/java/com/seoul42/saver_android/MyWebClient.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/MyWebClient.kt
@@ -1,0 +1,106 @@
+package com.seoul42.saver_android
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+
+import androidx.appcompat.app.AppCompatActivity
+import com.facebook.CallbackManager
+import com.facebook.FacebookCallback
+import com.facebook.FacebookException
+import com.facebook.share.Sharer
+import com.facebook.share.model.ShareLinkContent
+import com.facebook.share.widget.ShareDialog
+import java.net.URISyntaxException
+
+class MyWebClient private  constructor() : android.webkit.WebViewClient() {
+    private var callbackManager: CallbackManager? = null
+    private var shareDialog: ShareDialog? = null
+    private var packageManager: PackageManager? = null
+    private var activity: AppCompatActivity? = null
+    private var isRedirect = false
+
+
+    constructor(activity: AppCompatActivity, packageManager: PackageManager) : this() {
+        this.activity = activity
+        this.packageManager = packageManager
+        callbackManager = CallbackManager.Factory.create();
+        shareDialog = ShareDialog(activity);
+
+        shareDialog?.registerCallback(callbackManager, object : FacebookCallback<Sharer.Result> {
+            override fun onSuccess(result: Sharer.Result?) {
+                Log.d("#", "성공")
+                activity.onBackPressed()
+            }
+
+            override fun onCancel() {
+                Log.d("#", "취소")
+                activity.onBackPressed()
+            }
+
+            override fun onError(error: FacebookException?) {
+                Log.d("#", "실패" + error.toString())
+                activity.onBackPressed()
+            }
+        });
+    }
+
+    public fun getCallbackManager(): CallbackManager? {
+        return callbackManager
+    }
+
+    public fun setIsDirect(isRedirect: Boolean) {
+        this.isRedirect = isRedirect
+    }
+
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+
+        if (isRedirect)
+            return false
+        else
+            isRedirect = true
+
+        if (request.url.scheme == "intent") {
+            try {
+                // Intent 생성
+                val intent = Intent.parseUri(request.url.toString(), Intent.URI_INTENT_SCHEME)
+
+                // 실행 가능한 앱이 있으면 앱 실행
+                if (packageManager != null && intent.resolveActivity(packageManager!!) != null) {
+                    activity?.startActivity(intent)
+                    return true
+                }
+                // Fallback URL이 있으면 현재 웹뷰에 로딩
+                val fallbackUrl = intent.getStringExtra("browser_fallback_url")
+                if (fallbackUrl != null) {
+                    view.loadUrl(fallbackUrl)
+                    return true
+                }
+
+            } catch (e: URISyntaxException) {
+                Log.e("error", "Invalid intent request", e)
+            }
+        }
+        //페이스북 연결인 경우
+        else if (request.url.host?.contains("facebook") == true) {
+            try {
+                var url = request.url.toString()
+                url = url.substring(url.indexOf("u=") + 2, url.length)
+                //페이스북 링크 설정
+                val linkContent = ShareLinkContent.Builder()
+                    .setContentUrl(Uri.parse(url)).build()
+                //모드를 AUTOMATIC으로 설정해 페이스북 앱이 있으면 앱을 연결시켜주고 없으면 다이얼로그를  보여줌
+                shareDialog?.show(linkContent, ShareDialog.Mode.AUTOMATIC)
+                return true
+            } catch (e: URISyntaxException) {
+                Log.e("#error", "Invalid intent request", e)
+            }
+        }
+        return false
+
+    }
+}

--- a/saver-android/app/src/main/res/layout/activity_main.xml
+++ b/saver-android/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/constraint_layout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"

--- a/saver-android/app/src/main/res/values/themes.xml
+++ b/saver-android/app/src/main/res/values/themes.xml
@@ -2,7 +2,7 @@
     <!-- Base application theme. -->
     <style name="Theme.Saverandroid" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimary">@color/blue</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
         <!-- Secondary brand color. -->


### PR DESCRIPTION
# 개요

# 작업사항

 -앱이 있을경우 앱을 열고 앱이 없을 경우 웹뷰로 열도록 설정

## 메인화면



# 참고사항
- [페이스북 Android에서 공유](https://developers.facebook.com/docs/sharing/android)
- api 30 버전에서 앱이 열리지 않는 버그가 있었는데 [Facebook Android SDK FAQ 및 문제 해결](https://developers.facebook.com/docs/android/troubleshooting/) 맨 위 토글에 해답이 있었습니다.
- 의존성 충돌이 발생합니다.  gradle.properties 에 다음 코드를 추가해주세요([AndroidX로 이전 참고](https://developer.android.com/jetpack/androidx/migrate?hl=ko))
```
android.useAndroidX=true
android.enableJetifier=true
```
- 구현 방법은 [CMS 3기 노션](https://www.notion.so/cms-3rd/f4912e8b9dfa41fbbf22bb5a57a1be5c) 에 정리해놓았습니다.
- 딥링크 설정이 되어있는데 페이지가 안열려서 뭐가 문젠가 했더니 페이스북 앱 자체에서 막아놓았네요 [링크](https://www.ricksdailytips.com/force-facebook-app-to-open-links-in-browser/) 참조해서 설정 해제하니까 정상동작합니다.