### PR TITLE
fix : #324 북마크 a 태그 크기 오류

### DIFF
--- a/saver-web/public/javascripts/bookmarkInfiniteScroll.js
+++ b/saver-web/public/javascripts/bookmarkInfiniteScroll.js
@@ -134,8 +134,9 @@ function fillBookmark(template, article, articleId) {
     'beforeend',
     `
       <div class="bookmark-section-text-area">
-        <a href="articles/detail/${articleId}"></a>
+        <a href="articles/detail/${articleId}">
         <p class="bookmark-section-text-text">${article.headline}</p>
+        </a>
       </div>
 `,
   );


### PR DESCRIPTION

# 개요
-북마크 a태그 크기가 0으로 나타나는 버그 수정

# 작업사항
- p 태그를 a 태그로 감싸도록 수정

## 메인화면



# 참고사항
