### PR TITLE
fix: #337 섹션페이지 등 폰트 미적용 오류 수정

### DIFF
--- a/saver-web/public/stylesheets/icons/fold-button-text.svg
+++ b/saver-web/public/stylesheets/icons/fold-button-text.svg
@@ -5,7 +5,7 @@
         </style>
     </defs>
     <g transform="translate(-90.587 -931.636)">
-        <text fill="#434343" font-family="NotoSansCJKkr-Bold, Noto Sans CJK KR" font-size="13px" font-weight="700" letter-spacing="-0.005em" transform="translate(114.587 946.636)">
+        <text fill="#434343" font-family="Noto Sans KR, sans-serif" font-size="13px" font-weight="700" letter-spacing="-0.005em" transform="translate(114.587 946.636)">
             <tspan x="-23.855" y="0">접기</tspan>
         </text>
         <g>

--- a/saver-web/public/stylesheets/icons/more-button-text.svg
+++ b/saver-web/public/stylesheets/icons/more-button-text.svg
@@ -5,7 +5,7 @@
         </style>
     </defs>
     <g id="그룹_635" transform="translate(-62.587 -931.636)">
-        <text id="더_자세히" fill="#434343" font-family="NotoSansCJKkr-Bold, Noto Sans CJK KR" font-size="13px" font-weight="700" letter-spacing="-0.005em" transform="translate(88.587 946.636)">
+        <text id="더_자세히" fill="#434343" font-family="Noto Sans KR, sans-serif" font-size="13px" font-weight="700" letter-spacing="-0.005em" transform="translate(88.587 946.636)">
             <tspan x="-25.265" y="0">더 자세히</tspan>
         </text>
         <g id="그룹_270" transform="translate(121.087 935)">

--- a/saver-web/public/stylesheets/user/pages/section.css
+++ b/saver-web/public/stylesheets/user/pages/section.css
@@ -10,6 +10,7 @@
   position: relative;
   top: 50px;
   padding-bottom: 40px;
+  font-family: 'Noto Sans KR', sans-serif;
 }
 
 .section-div {


### PR DESCRIPTION
# 개요
- 섹션페이지의 전반적인 폰트 및 메인 인덱스 페이지의 더 자세히/ 접기 버튼의 폰트가 제대로 표시되지 않던 오류

# 작업사항
- 버튼 관련 svg 파일 및 섹션페이지의 폰트 수정했습니다.

# 참고사항
- svg파일을 수정해도 이상이 없는지 원래 폰트가 정상적으로 표시되던 분들이 체크해주셨으면 합니다.