### PR TITLE
feat: #326 안드로이드 앱에 JavascriptInterface 인터페이스 추가

### DIFF
--- a/saver-android/app/src/main/java/com/seoul42/saver_android/MainActivity.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : AppCompatActivity() {
         MyWebClient(this@MainActivity, packageManager)
     }
 
-    private val baseUrl = "http://192.168.0.5:1234/";
+    private val baseUrl = "http://thesaver.io/";
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/saver-android/app/src/main/java/com/seoul42/saver_android/MyWebClient.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/MyWebClient.kt
@@ -22,7 +22,7 @@ class MyWebClient private  constructor() : android.webkit.WebViewClient() {
     private var packageManager: PackageManager? = null
     private var activity: AppCompatActivity? = null
     private var isRedirect = false
-
+    private var view : WebView? = null
 
     constructor(activity: AppCompatActivity, packageManager: PackageManager) : this() {
         this.activity = activity
@@ -33,17 +33,20 @@ class MyWebClient private  constructor() : android.webkit.WebViewClient() {
         shareDialog?.registerCallback(callbackManager, object : FacebookCallback<Sharer.Result> {
             override fun onSuccess(result: Sharer.Result?) {
                 Log.d("#", "성공")
-                activity.onBackPressed()
+                view?.loadUrl("javascript:window.close();");
+               // activity.onBackPressed()
             }
 
             override fun onCancel() {
                 Log.d("#", "취소")
-                activity.onBackPressed()
+                view?.loadUrl("javascript:window.close();");
+                //activity.onBackPressed()
             }
 
             override fun onError(error: FacebookException?) {
                 Log.d("#", "실패" + error.toString())
-                activity.onBackPressed()
+                view?.loadUrl("javascript:window.close();");
+               // activity.onBackPressed()
             }
         });
     }
@@ -63,7 +66,7 @@ class MyWebClient private  constructor() : android.webkit.WebViewClient() {
             return false
         else
             isRedirect = true
-
+        this.view = view
         if (request.url.scheme == "intent") {
             try {
                 // Intent 생성

--- a/saver-android/app/src/main/java/com/seoul42/saver_android/WebAppInterface.kt
+++ b/saver-android/app/src/main/java/com/seoul42/saver_android/WebAppInterface.kt
@@ -1,0 +1,34 @@
+package com.seoul42.saver_android
+
+import android.util.Log
+import android.webkit.JavascriptInterface
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.ktx.messaging
+
+class WebAppInterface  {
+    @JavascriptInterface
+  fun subscribeTopic(topic: String) {
+        Firebase.messaging.subscribeToTopic(topic)
+            .addOnCompleteListener { task ->
+                var msg = ""
+                msg = if (task.isSuccessful)
+                    "$topic 성공"
+                else
+                    "$topic 실패"
+                Log.d("구독", msg)
+            }
+    }
+    @JavascriptInterface
+    fun unsubscribeTopic(topic: String) {
+        Firebase.messaging.unsubscribeFromTopic(topic)
+            .addOnCompleteListener { task ->
+                var msg = "성공"
+                if (!task.isSuccessful) {
+                    msg = "실패"
+                }
+                Log.d("구독 취소", msg)
+            }
+
+    }
+
+}


### PR DESCRIPTION
# 개요
- 웹에서 안드로이드의 함수를 실행시킬 수 있도록 JavascriptInterface
  인터페이스 추가
- 웹뷰에서 다른페이지로 이동한 후에 메인으로 돌아와서 페이스북 공유시
  생기는 오류 수정

# 작업사항
- JavascriptInterface 인터페이스 추가 후 구독 함수를 옮김
- MyWebViewClient.registerCallback() 에서 모두 끝났을때 현재 뷰를 닫도록 수정

## 메인화면



# 참고사항
-[웹뷰와 앱간의 통신 예제](https://black-jin0427.tistory.com/272)

# 테스트 방법
- views\user\loginedSection.ejs 에  `alert('팔로우 되었습니다.');` 밑에 `Android.subscribeTopic("토픽")` 추가
- section탭에서 팔로우 버튼을 누르고 alret을 껐을때 android studio 로그캣에 구독 성공이 뜨면 됨
- [노션](https://www.notion.so/cms-3rd/aff89996b5944ef5b99f1ed9d5f8b9ee)에 정리해두었으니 참고 부탁드립니다.