### PR TITLE
feat: #358 관리자페이지 최근 수정 순으로 기사 정렬

### DIFF
--- a/saver-web/controllers/author/article/articleController.js
+++ b/saver-web/controllers/author/article/articleController.js
@@ -1,5 +1,5 @@
 
-const { Author, Article, Invitation } = require('../../../models');
+const { Author, Article } = require('../../../models');
 
 const getCurrentUser = require('../../../lib/getCurrentUser');
 
@@ -176,8 +176,10 @@ const editMeetingPage = async (req, res, next) => {
 //내 기사 목록
 const myArticlePage = async (req, res, next) => {
 	const currentUser = await getCurrentUser(req.user ? req.user.id : null);
-	const author = await Author.findOne({ where: { id: req.user.id } });
-	const articles = await author.getArticles();
+	const articles = await Article.findAll({
+		where: { AuthorId: req.user.id},
+		order: [['updatedAt', 'DESC']],
+	})
 	return res.render('author/articles', {
 		title: 'my articles',
 		articles,

--- a/saver-web/controllers/author/authorController.js
+++ b/saver-web/controllers/author/authorController.js
@@ -28,6 +28,7 @@ const indexPage = async (req, res) => {
 	const articles = await Article.findAll({
 		where: { category },
 		include: { model: Author, attributes: ['id', 'name', 'category'] },
+		order: [['updatedAt', 'DESC']]
 	}); //db에서 사용자 데이터 가져오기
 	const { position } = currentUser;
 	// 기사, 데스크, 편집장인 경우 보여지는 부분이 있

--- a/saver-web/controllers/firebase/firebaseController.js
+++ b/saver-web/controllers/firebase/firebaseController.js
@@ -35,6 +35,7 @@ const pushPage = async (req, res) => {
   const articles = await Article.findAll({
     offset: page * limit,
     limit: limit,
+    order: [['updatedAt', 'DESC']],
   });
 
   var totalPage = await Article.count({});

--- a/saver-web/controllers/firebase/firebaseController.js
+++ b/saver-web/controllers/firebase/firebaseController.js
@@ -33,9 +33,10 @@ const pushPage = async (req, res) => {
   const page = req.query.page ? parseInt(req.query.page) : 0;
   const limit = 15;
   const articles = await Article.findAll({
+    where: { status: STATUS.CONFIRMED}, //ne == not equal
     offset: page * limit,
     limit: limit,
-    order: [['updatedAt', 'DESC']],
+    order: [['publishedAt', 'DESC']],
   });
 
   var totalPage = await Article.count({});

--- a/saver-web/views/author/pushPage.ejs
+++ b/saver-web/views/author/pushPage.ejs
@@ -15,7 +15,7 @@
         <th class="table-header__cell">No</th>
         <th class="table-header__cell">헤드라인</th>
         <th class="table-header__cell">카테고리</th>
-        <th class="table-header__cell">작성일시</th>
+        <th class="table-header__cell">게제 일자</th>
         <th class="table-header__cell">출고 상황</th>
         <th class="table-header__cell">푸시 알림</th>
 
@@ -33,7 +33,7 @@
           <% } %>
         </td>
         <td class="table-body__cell"><%= article.category %></td>
-        <td class="table-body__cell"><%= article.updatedAt %></td>
+        <td class="table-body__cell"><%= article.publishedAt %></td>
         <td class="table-body__cell"><%= article.status === 4 ? 'O' : 'X' %></td>
         <td>
           <a  href=<%=`/author/push/send/${article.id}` %>  id =<%= `push-${article.id}` %> style="font-size:14.4px"  class = "btn btn-primary push">보내기</a>

--- a/saver-web/views/author/pushPage.ejs
+++ b/saver-web/views/author/pushPage.ejs
@@ -15,7 +15,7 @@
         <th class="table-header__cell">No</th>
         <th class="table-header__cell">헤드라인</th>
         <th class="table-header__cell">카테고리</th>
-        <th class="table-header__cell">게제 일자</th>
+        <th class="table-header__cell">게재 일자</th>
         <th class="table-header__cell">출고 상황</th>
         <th class="table-header__cell">푸시 알림</th>
 


### PR DESCRIPTION
# 개요
- 홈, 내 기사목록, 알림 보내기 페이지의 기사들 정렬.

# 작업사항
- db 불러올 때 부터 정렬해서 불러오는 방식으로 구현했습니다.

# 참고사항

 - 알림페이지에 나오는 시간이 update 시간이라서 update 시간으로 정렬했는데 이미 발행해서 알림도 간 기사가 수정돼서 위에 나타나면 헷갈릴 수 있을 것 같아서 발행일 기준으로 정렬하는 것도 좋을 것 같습니다.
 - 알림페이지만 발행일로 정렬.