### PR TITLE
fix: #424 node-schedule 오작동 해결

### DIFF
--- a/saver-web/lib/scheduler.js
+++ b/saver-web/lib/scheduler.js
@@ -1,16 +1,11 @@
 const schedule = require('node-schedule');
 const ampmCtrl = require('../controllers/today/ampmController');
 
-const amSchedule = new schedule.RecurrenceRule();
-amSchedule.hour = 7;
-const pmSchedule = new schedule.RecurrenceRule();
-pmSchedule.hour = 19;
-
 const scheduler = () => {
-    schedule.scheduleJob(amSchedule, () => {
+    schedule.scheduleJob('0 7 * * * ', () => {
         ampmCtrl.createAMPM(true);
     });
-    schedule.scheduleJob(pmSchedule, () => {
+    schedule.scheduleJob('0 19 * * *', () => {
         ampmCtrl.createAMPM(false);
     });
 }


### PR DESCRIPTION
# 개요
- minute을 설정해주지 않아서 생긴 에러로 추정

# 작업사항
- minute 추가하면서 직관적으로 cron 형태로 수정했습니다.
- node-schedule 실행이 안되던 에러는 서버 restart 하니까 해결되었습니다.
 