### PR TITLE
feat: #245 이전 기사 링크 추가 기능 구현

### DIFF
--- a/saver-web/controllers/author/article/articleController.js
+++ b/saver-web/controllers/author/article/articleController.js
@@ -5,6 +5,8 @@ const getCurrentUser = require('../../../lib/getCurrentUser');
 const POSITION = require('../../../lib/constants/position');
 const STATUS = require('../../../lib/constants/articleStatus');
 const { constants } = require('../../../lib/converter');
+const sequelize = require('sequelize');
+const Op = sequelize.Op;
 
 const newArticleRequest = async (req, res, next) => {
   const {
@@ -214,11 +216,31 @@ const previewPage = async (req, res, next) => {
   res.render('user/article', { title: 'preview', article, POSITION, layout: 'layout/userLayout' });
 };
 
+const searchArticles = async (req, res, next) => {
+  const currentUser = await getCurrentUser(req.user?.id);
+  if (!currentUser) return res.redirect('/author/login');
+  try {
+    const article = await Article.findAll({
+      where: {
+        headline: {
+          [Op.like]: '%' + req.query.word + '%',
+        },
+      },
+      attributes: ['id', 'headline'],
+    });
+    res.status(200).json({ article });
+  } catch (e) {
+    console.log(e);
+    res.status(200).json({ error: e });
+  }
+};
+
 module.exports = {
   request: {
     newArticle: newArticleRequest,
     editArticle: editArticleRequest,
     deskProcess: deskProcessRequest,
+    searchArticles,
   },
   page: {
     newArticle: newArticlePage,

--- a/saver-web/public/javascripts/author/newArticle.js
+++ b/saver-web/public/javascripts/author/newArticle.js
@@ -1,124 +1,124 @@
-
 class Editor {
+  constructor() {
+    this.briefingEditor;
+    this.paragraphsEditor;
+  }
 
-	constructor() {
-		this.briefingEditor;
-		this.paragraphsEditor;
-	}
+  createEditor = (selector, editorContent) => {
+    if ($(selector)) {
+      const editor = $(selector).summernote();
+      $(selector).summernote('code', editorContent);
 
-	createEditor = (selector, editorContent) => {
-		if ($(selector)) {
-			const editor = $(selector).summernote();
-			$(selector).summernote('code', editorContent)
+      // 붙여넣을 경우 이벤트리스너
+      editor.on('summernote.paste', function (e, ne) {
+        setTimeout(() => {
+          var badAttributes = ['style', 'width', 'hegith'];
+          let output = editor.summernote('code');
 
-			// 붙여넣을 경우 이벤트리스너
-			editor.on('summernote.paste', function (e, ne) {
-				setTimeout(() => {
-					var badAttributes = ['style', 'width', 'hegith'];
-					let output = editor.summernote('code');
+          // 문자열에서 style="" 어트리뷰트를 공백으로 치환
+          for (var i = 0; i < badAttributes.length; i++) {
+            var attributeStripper = new RegExp(' ' + badAttributes[i] + '="(.*?)"', 'gi');
+            output = output.replace(attributeStripper, '');
+          }
+          editor.summernote('code', output);
+        }, 10);
+      });
 
-					// 문자열에서 style="" 어트리뷰트를 공백으로 치환
-					for (var i = 0; i < badAttributes.length; i++) {
-						var attributeStripper = new RegExp(' ' + badAttributes[i] + '="(.*?)"', 'gi');
-						output = output.replace(attributeStripper, '');
-					}
-					editor.summernote('code', output)
-				}, 10)
-			})
+      return editor;
+    } else {
+      throw '셀렉터를 확인해주세요';
+    }
+  };
+  getBriefingMarkUp = () => {
+    const content = this.briefingEditor.summernote('code');
+    return content;
+  };
 
-			return editor;
-		} else {
-			throw '셀렉터를 확인해주세요';
-		}
-	}
-	getBriefingMarkUp = () => {
-		const content = this.briefingEditor.summernote('code');
-		return content;
-	}
+  getParagraphsMarkUp = () => {
+    const content = this.paragraphsEditor.summernote('code');
+    return content;
+  };
 
-	getParagraphsMarkUp = () => {
-		const content = this.paragraphsEditor.summernote('code');
-		return content;
-	}
+  createArticle = (data) => {
+    axios({
+      method: 'post',
+      url: `/author/createArticle`,
+      data,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+      .then((res) => {
+        if (res.data.result) {
+          alert('등록되었습니다');
+          location.href = '/author/articles';
+        }
+      })
+      .catch((err) => {
+        alert('실패하였습니다');
+        console.error(err);
+      });
+  };
 
-	createArticle = (data) => {
-		axios({
-			method: 'post',
-			url: `/author/createArticle`,
-			data,
-			headers: {
-				'Content-Type': 'multipart/form-data'
-			}
-		}).then((res) => {
-			if (res.data.result) {
-				alert('등록되었습니다');
-				location.href = '/author/articles';
-			}
-		}).catch((err) => {
-			alert('실패하였습니다');
-			console.error(err);
-		})
-	};
+  getForm = (status) => {
+    const payload = new FormData();
+    payload.append('status', status);
+    payload.append('category', $('#category')[0].value);
+    payload.append('headline', $('#headline')[0].value);
+    if ($('#picture')[0].files[0]) {
+      payload.append('picture', $('#picture')[0].files[0], $('#picture')[0].files[0].name);
+      // 이미지는 blob타입으로 formData에 저장되며, 해당 경우 세번째 파라미터에 파일이름을 지정해줘야한다.
+    }
+    payload.append('imageDesc', $('#imageDesc')[0].value);
+    payload.append('imageFrom', $('#imageFrom')[0].value);
+    payload.append('briefing', escape(this.getBriefingMarkUp()));
+    payload.append('paragraphs', escape(this.getParagraphsMarkUp()));
+    return payload;
+  };
 
-	getForm = (status) => {
-		const payload = new FormData();
-		payload.append('status', status);
-		payload.append('category', $('#category')[0].value);
-		payload.append('headline', $('#headline')[0].value);
-		if ($('#picture')[0].files[0]) {
-			payload.append('picture', $('#picture')[0].files[0], $('#picture')[0].files[0].name);
-			// 이미지는 blob타입으로 formData에 저장되며, 해당 경우 세번째 파라미터에 파일이름을 지정해줘야한다.
-		}
-		payload.append('imageDesc', $('#imageDesc')[0].value);
-		payload.append('imageFrom', $('#imageFrom')[0].value);
-		payload.append('briefing',  escape(this.getBriefingMarkUp()));
-		payload.append('paragraphs',  escape(this.getParagraphsMarkUp()));
-		return payload;
-	}
+  addEvent = () => {
+    $('form').on('submit', (e) => {
+      e.preventDefault();
+    });
+    $('button[name="saveBtn"]').on('click', async () => {
+      const briefing = this.getBriefingMarkUp();
 
-	addEvent = () => {
-		$('form').on('submit', (e) => {
-			e.preventDefault()
-		})
-		$('button[name="saveBtn"]').on('click', async () => {
-			const briefing = this.getBriefingMarkUp();
-			if (!briefing) {
-				alert('100자 브리핑이 비어있습니다!')
-				return 0;
-			}
-			window.removeEventListener('beforeunload', confirmExit);
-			const form = this.getForm(STATUS.DRAFTS);
-			this.createArticle(form)
-		});
+      if (!briefing) {
+        alert('100자 브리핑이 비어있습니다!');
+        return 0;
+      }
+      window.removeEventListener('beforeunload', confirmExit);
+      const form = this.getForm(STATUS.DRAFTS);
+      this.createArticle(form);
+    });
 
-		$('button[name="completeBtn"]').on('click', async () => {
-			if (!this.getBriefingMarkUp()) {
-				alert('100자 브리핑이 비어있습니다!')
-				return 0;
-			}
-			window.removeEventListener('beforeunload', confirmExit);
-			const form = this.getForm(STATUS.COMPLETED);
-			this.createArticle(form)
-		});
-	}
+    $('button[name="completeBtn"]').on('click', async () => {
+      if (!this.getBriefingMarkUp()) {
+        alert('100자 브리핑이 비어있습니다!');
+        return 0;
+      }
+      window.removeEventListener('beforeunload', confirmExit);
+      const form = this.getForm(STATUS.COMPLETED);
+      this.createArticle(form);
+    });
+  };
 
-	init = (briefingContent, paragraphsContent) => {
-		console.log({ briefingContent, paragraphsContent });
-		this.briefingEditor = this.createEditor('#editor_briefing', briefingContent)
-		this.paragraphsEditor = this.createEditor('#editor_paragraphs', paragraphsContent)
-	}
+  init = (briefingContent, paragraphsContent) => {
+    this.briefingEditor = this.createEditor('#editor_briefing', briefingContent);
+    this.paragraphsEditor = this.createEditor('#editor_paragraphs', paragraphsContent);
+  };
 }
 
-
 $(document).ready(function () {
-	window.addEventListener('beforeunload', confirmExit);
-	const editor = new Editor();
-	editor.init('', '')
-	editor.addEvent()
+  window.addEventListener('beforeunload', confirmExit);
+  const editor = new Editor();
+  editor.init('', '');
+
+  editor.addEvent();
 });
 
 window.addEventListener('beforeunload', confirmExit);
 
 function confirmExit() {
-	return "정말 페이지를 벗어나시겠습니까?";
+  return '정말 페이지를 벗어나시겠습니까?';
 }

--- a/saver-web/public/javascripts/author/searchBox.js
+++ b/saver-web/public/javascripts/author/searchBox.js
@@ -1,0 +1,65 @@
+function clickSearchlist(headline, link) {
+  const ulElement = document.getElementById('search-ul');
+  const linkElement = document.getElementsByClassName('news-link');
+  var target;
+  var place = 'afterbegin';
+  if (linkElement.length === 0) {
+    target = document.getElementsByClassName('note-editable')[1];
+  } else {
+    target = linkElement[linkElement.length - 1].parentElement;
+    place = 'afterend';
+  }
+  target?.insertAdjacentHTML(
+    place,
+    `<p >
+		  <a class="news-link" href="${link}" target="_blank">${linkElement.length + 1}. ${headline}</a>
+	  </p>`,
+  );
+  ulElement.innerHTML = '';
+}
+
+function searchConnectedNews() {
+  const searchbtn = document.getElementById('search');
+  const serchInput = document.getElementById('connected');
+  const ulElement = document.getElementById('search-ul');
+  searchbtn.addEventListener('click', () => {
+    ulElement.innerHTML = '';
+    const searchWord = serchInput.value;
+    if (!searchWord || searchWord === '') return;
+
+    $.ajax({
+      url: `/author/searchArticles?word=${searchWord}`,
+      type: 'get',
+      success: function (result) {
+        const temp = result.article;
+        temp.map(function (article) {
+          ulElement.insertAdjacentHTML(
+            'beforeend',
+            `<li>
+			<button class="search-result-btn" id="${
+        article.id
+      }" formnovalidate>${article.headline.trim()}</button>
+		  </li>`,
+          );
+        });
+
+        const resultBtns = document.getElementsByClassName('search-result-btn');
+        for (var i = 0; i < resultBtns.length; i++) {
+          resultBtns[i].addEventListener('click', (e) => {
+            clickSearchlist(
+              e.target.innerText,
+              `${window.location.protocol}//${window.location.host}/articles/detail/${e.target.id}`,
+            );
+          });
+        }
+      },
+      error: function (err) {
+        console.log(err);
+      },
+    });
+  });
+}
+
+window.addEventListener('load', () => {
+  searchConnectedNews();
+});

--- a/saver-web/public/stylesheets/author/common.css
+++ b/saver-web/public/stylesheets/author/common.css
@@ -1,5 +1,5 @@
 body {
-  font-family: "Roboto", sans-serif;
+  font-family: 'Roboto', sans-serif;
   background-color: #f8fafb;
 }
 
@@ -8,8 +8,7 @@ body {
 }
 
 .login,
-.presignup
- {
+.presignup {
   position: absolute;
   width: 100%;
   top: 30%;
@@ -31,14 +30,42 @@ div.signup {
 }
 
 .form-block .form-label {
-	font-size: 20px;
-    margin-top: 20px;
+  font-size: 20px;
+  margin-top: 20px;
+}
+
+.search-result-box {
+  margin: 0;
+  border: 1px solid #e2e2e2;
+  outline: none;
+  border-radius: 5px;
+  border-top: 0px;
+  border-bottom: 0px;
+  background: white;
+}
+
+.search-result-ul {
+  margin: 0;
+}
+
+.search-result-btn {
+  padding: 8px;
+  margin: 0;
+  border: none;
+  outline: none;
+  white-space: nowrap;
+  overflow: hidden;
+  width: 100%;
+  border-bottom: 1px solid #e2e2e2;
+  background: white;
+  text-overflow: ellipsis;
 }
 
 /* sumemrnote css */
 .note-editable {
-	background-color: white;
+  background-color: white;
 }
-img[alt="current-picture"] {
-	border: 1px solid #ddd;
+
+img[alt='current-picture'] {
+  border: 1px solid #ddd;
 }

--- a/saver-web/routes/author.js
+++ b/saver-web/routes/author.js
@@ -50,6 +50,7 @@ module.exports = (passport) => {
     authorCtrl.request.newArticle,
   );
   router.post('/desk-process', loggedIn, authorCtrl.request.deskProcess);
+  router.get('/searchArticles', loggedIn, authorCtrl.request.searchArticles);
 
   /**
    * 기자 관리

--- a/saver-web/views/author/editArticle.ejs
+++ b/saver-web/views/author/editArticle.ejs
@@ -51,6 +51,43 @@
 
                     </div>
                     <div class="mb-4">
+                      <div class="article__connected">
+                        <label required class="form-label" for="connected">연결 기사 찾기</label>
+                        <div
+                          style="display: flex; justify-content: space-between; align-items: center"
+                        >
+                          <input
+                            class="form-control"
+                            type="text"
+                            id="connected"
+                            name="connected"
+                            placeholder="연결된 기사의 헤드라인을 입력해주세요"
+                            maxlength="255"
+                            style="margin-right: 5px;"
+                          />
+                          <button
+                            id="search"
+                            class="btn btn-primary"
+                            style="min-width: 80px"
+                            formnovalidate
+                          >
+                            찾기
+                          </button>
+                        </div>
+                        <div
+                          id="result"
+                          class="search-result-box"
+                          style="max-height: 250px; overflow-y: auto"
+                        >
+                          <ul
+                            id="search-ul"
+                            class="search-result-ul"
+                            style="padding: 0; list-style-type: none"
+                          ></ul>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="mb-4">
                       <label class="form-label" for="breifing">
                         소단락
                         <i class="text-muted">
@@ -88,3 +125,4 @@
             <script src="/vendors/summernote/summernote-lite.js" defer></script>
             <link href="/vendors/summernote/summernote-lite.css" rel="stylesheet">
             <script type="module" src="/javascripts/author/editArticle.js"></script>
+            <script type="module" src="/javascripts/author/searchBox.js"></script>

--- a/saver-web/views/author/newArticle.ejs
+++ b/saver-web/views/author/newArticle.ejs
@@ -1,10 +1,7 @@
-<%- contentFor('navbar') %>
-<%- include('../partials/navbar.ejs') %>
-
-<%- contentFor('body') %>
+<%- contentFor('navbar') %> <%- include('../partials/navbar.ejs') %> <%- contentFor('body') %>
 <div class="content">
   <div class="container">
-    <div class="row justify-content-center" >
+    <div class="row justify-content-center">
       <div class="col-md-6 contents">
         <div class="row justify-content-center">
           <div class="col-md-12">
@@ -16,48 +13,110 @@
               <form class="needs-validation">
                 <div class="mb-4">
                   <label class="form-label" for="category">카테고리</label>
-                  <select required class="form-control" name="category" id="category" >
+                  <select required class="form-control" name="category" id="category">
                     <% Object.keys(category).filter(key => key !== '전체').forEach((key) => { %>
-                      <option value="<%=category[key]%>" >
-                        <%=key%>
-                      </option>
+                    <option value="<%=category[key]%>"><%=key%></option>
                     <% }) %>
                   </select>
                 </div>
                 <div class="mb-4">
                   <div class="article__headline">
-                      <label required class="form-label" for="headline">헤드라인</label>
-                      <input class="form-control" type="text" id="headline" name="headline" placeholder="뉴스의 헤드라인을 입력해주세요" maxlength="255" />
+                    <label required class="form-label" for="headline">헤드라인</label>
+                    <input
+                      class="form-control"
+                      type="text"
+                      id="headline"
+                      name="headline"
+                      placeholder="뉴스의 헤드라인을 입력해주세요"
+                      maxlength="255"
+                    />
                   </div>
                 </div>
                 <div class="mb-4">
                   <label class="form-label" for="picture">사진</label>
-                  <input required class="form-control" type="file" id="picture" name="picture" accept="image/gif, image/jpeg, image/png" />
+                  <input
+                    required
+                    class="form-control"
+                    type="file"
+                    id="picture"
+                    name="picture"
+                    accept="image/gif, image/jpeg, image/png"
+                  />
                   <label class="form-label" for="imageDesc">사진 설명</label>
-                  <input required class="form-control" type="text" id="imageDesc" name="imageDesc" placeholder="사진에 대한 설명을 적어주세요" />
+                  <input
+                    required
+                    class="form-control"
+                    type="text"
+                    id="imageDesc"
+                    name="imageDesc"
+                    placeholder="사진에 대한 설명을 적어주세요"
+                  />
                   <label class="form-label" for="imageFrom">사진 출처</label>
-                  <input required class="form-control" type="text" id="imageFrom" name="imageFrom" placeholder="사진에 대한 출처를 적어주세요" />
+                  <input
+                    required
+                    class="form-control"
+                    type="text"
+                    id="imageFrom"
+                    name="imageFrom"
+                    placeholder="사진에 대한 출처를 적어주세요"
+                  />
                 </div>
                 <div class="mb-4">
                   <label class="form-label" for="breifing">100자 브리핑</label>
                   <div id="editor_briefing"></div>
                 </div>
                 <div class="mb-4">
-					<label class="form-label" for="breifing">
-						소단락
-						<i class="text-muted">
-							([더 자세히버튼]을 누르면 보여지는 내용입니다)
-						</i>
-					</label>
-					<div id="editor_paragraphs"></div>
+                  <div class="article__connected">
+                    <label required class="form-label" for="connected">연결 기사 찾기</label>
+                    <div style="display: flex; justify-content: space-between; align-items: center">
+                      <input
+                        class="form-control"
+                        type="text"
+                        id="connected"
+                        name="connected"
+                        placeholder="연결된 기사의 헤드라인을 입력해주세요"
+                        maxlength="255"
+                        style="margin-right: 5px"
+                      />
+                      <button
+                        id="search"
+                        class="btn btn-primary"
+                        style="min-width: 80px"
+                        formnovalidate
+                      >
+                        찾기
+                      </button>
+                    </div>
+                    <div
+                      id="result"
+                      class="search-result-box"
+                      style="max-height: 250px; overflow-y: auto"
+                    >
+                      <ul
+                        id="search-ul"
+                        class="search-result-ul"
+                        style="padding: 0; list-style-type: none"
+                      ></ul>
+                    </div>
+                  </div>
+                </div>
+                <div class="mb-4">
+                  <label class="form-label" for="breifing">
+                    소단락
+                    <i class="text-muted"> ([더 자세히버튼]을 누르면 보여지는 내용입니다) </i>
+                  </label>
+                  <div id="editor_paragraphs"></div>
                 </div>
                 <div class="d-grid gap-2 mt-4">
-                  <button class="article--save btn btn-primary" name="saveBtn" type="submit">임시저장</button>
-                  <button class="article--complete btn btn-info" name="completeBtn" type="submit">출고</button>
+                  <button class="article--save btn btn-primary" name="saveBtn" type="submit">
+                    임시저장
+                  </button>
+                  <button class="article--complete btn btn-info" name="completeBtn" type="submit">
+                    출고
+                  </button>
                 </div>
               </form>
             </div>
-
           </div>
         </div>
       </div>
@@ -66,17 +125,17 @@
 </div>
 
 <style>
-  .ce-toolbox__button[data-tool="linkTool"] {
+  .ce-toolbox__button[data-tool='linkTool'] {
     display: none;
   }
 </style>
 <script>
-	var STATUS = JSON.parse('<%-JSON.stringify(STATUS)%>')
+  var STATUS = JSON.parse('<%-JSON.stringify(STATUS)%>');
 </script>
 
-<%- contentFor('footer') %>
-<%- include('../partials/footer.ejs') %>
+<%- contentFor('footer') %> <%- include('../partials/footer.ejs') %>
 
 <script src="/vendors/summernote/summernote-lite.js" defer></script>
-<link href="/vendors/summernote/summernote-lite.css" rel="stylesheet">
+<link href="/vendors/summernote/summernote-lite.css" rel="stylesheet" />
 <script type="module" src="/javascripts/author/newArticle.js"></script>
+<script type="module" src="/javascripts/author/searchBox.js"></script>


### PR DESCRIPTION
# 개요
- 이전기사 링크가 소단락 윗부분에 추가될 수 있도록 구현

# 작업사항
- 제목 검색 api 추가
- 새 기사작성/ 기사 수정페이지에 검색부분 추가

## 메인화면

![검색 화면](https://user-images.githubusercontent.com/67669579/129906788-36ad7ca2-86c0-46fa-851f-cae94a4c79e7.PNG)

- 검색 결과를 클릭시 소단락에 기사 링크가 추가됩니다.
# 참고사항
