### PR TITLE
fix: 업데이트 버튼 먹통 오류 해결

### DIFF
--- a/saver-web/public/javascripts/author/index.js
+++ b/saver-web/public/javascripts/author/index.js
@@ -3,7 +3,7 @@ function getParameterByName(name) {
   return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
 }
 
-var table = document.querySelector('.table');
+var table = document.querySelector('.mytable');
 var select = document.querySelector('#category');
 
 table.addEventListener('change', function(e) {
@@ -59,6 +59,7 @@ const addEvent = () => {
       },
       currentTarget
     } = e;
+
     const articleId = parseInt(currentTarget.dataset.id);
 
     if (['am7', 'pm7'].indexOf(key) !== -1) {

--- a/saver-web/views/author/desking/desk.ejs
+++ b/saver-web/views/author/desking/desk.ejs
@@ -39,7 +39,7 @@
       </thead>
       <tbody class="table-body">
         <% articles.map((article)=> { %>
-        <tr class="table-body__row" name="cols">
+        <tr class="table-body__row" name="cols" data-id="<%= article.id %>">
           <td class="table-body__cell"><%= article.id %></td>
           <td class="table-body__cell">
             <a href="/author/articles/<%= article.id %>/preview" target="_blank"> <%= article.headline %> </a>

--- a/saver-web/views/author/today/todaywordDesking.ejs
+++ b/saver-web/views/author/today/todaywordDesking.ejs
@@ -18,7 +18,7 @@
 							<% words.map((word)=> { %>
 								<% console.log(word.id) %>
 
-									<tr class="table-body__row" name="cols">
+									<tr class="table-body__row" name="cols" data-id="<%= word.id %>">
 										<td class="table-body__cell">
 											<%= word.id %>
 										</td>

--- a/saver-web/views/author/todayArticle/todayArticleDesking.ejs
+++ b/saver-web/views/author/todayArticle/todayArticleDesking.ejs
@@ -18,7 +18,7 @@
       </thead>
       <tbody class="table-body">
         <% articles.map((article)=> { %>
-            <tr class="table-body__row" name="cols">
+            <tr class="table-body__row" name="cols" data-id="<%= article.id %>">
               <td class="table-body__cell">
                 <%= article.id %>
               </td>


### PR DESCRIPTION
# 개요
- 업데이트 버튼 먹통 오류 해결

# 작업사항
- 셀렉터가 이전 클래스명을 기준으로 대상을 찾고 있어서 이름 수정
- 데이터셋에서 아이디를 가져오는데 해당 로우에 데이터 아이디가 없어서 추가

## 메인화면



# 참고사항
