### PR TITLE
fix: #448 접기 시 원래기사페이지로 돌아오지 않는 버그

### DIFF
--- a/saver-web/public/javascripts/infiniteScroll.js
+++ b/saver-web/public/javascripts/infiniteScroll.js
@@ -95,7 +95,7 @@ $('#article-category').on( 'click', function() {
   $("#article-list").hide();
   $("#article-category-list").show();
   getCategoryPage();
-}); 
+});
 
 $('#article-all').on( 'click', function() {
   $('#article-category').removeClass('is-checked');
@@ -106,7 +106,7 @@ $('#article-all').on( 'click', function() {
   $("#article-category-list").hide();
   $("#article-list").show();
   getPage();
-}); 
+});
 
 
 function fixVidieo(article){
@@ -125,7 +125,8 @@ function fixVidieo(article){
 
 function makeTemplate(article) {
   //추가되는 카드들
-  return `<div class="article">
+  return `
+  <div id="article_0${article.id}" class="article">
   <div class="article__top">
     <div class="icon-${article.category}-black"></div>
     <p class="article__top__text ft-detail">
@@ -154,7 +155,7 @@ function makeTemplate(article) {
         <div class="title">
           <span id="share-close-${
             article.id
-          }" class="share-close">&times;</span>                                                        
+          }" class="share-close">&times;</span>
           <h3>공유하기</h3>
         </div>
         <br><hr style="border: solid 1px gray;"><br>
@@ -162,14 +163,14 @@ function makeTemplate(article) {
           <ul class="share-layer-content">
            <li>   <button id="kakao_share_${
              article.id
-           }" class="article_kakao_share-button"></button> </li> 
+           }" class="article_kakao_share-button"></button> </li>
            <li>   <button onclick="facebookshare('${document.location.href}articles/detail/${
     article.id
   }')"
-            class="article_facebook_share-button"></button></li> 
+            class="article_facebook_share-button"></button></li>
            <li>   <button onclick="urlshare('${document.location.href}articles/detail/${
     article.id
-  }')" class="article_url_share-button">url</button></li> 
+  }')" class="article_url_share-button">url</button></li>
           </ul>
         </div>
       </div>
@@ -179,7 +180,7 @@ function makeTemplate(article) {
         article.id
       })" class="article__control__right-buttons__share-button"></button>
       <button id="btn_bookmark-${article.id}" onclick="clickBookmark(
-        ${article.id}, 'btn_bookmark-${article.id}')" 
+        ${article.id}, 'btn_bookmark-${article.id}')"
         class="article__control__right-buttons__bookmark-button"></button>
     </div>
   </div>

--- a/saver-web/public/javascripts/user/index.js
+++ b/saver-web/public/javascripts/user/index.js
@@ -108,6 +108,7 @@ const addEvent = () => {
         $(`#editor_paragraphs_0${id}`).removeClass('open');
         originType = changeType;
         changeType = 'more';
+        location.href = `#article_0${id}`;
       }
       target.childNodes[1].className = target.childNodes[1].className.replace(
         originType,


### PR DESCRIPTION

# 개요
- ios에서 아래로 스크롤을 많이 내린 후에 접기버튼을 누를 경우 
- 해당 기사로 안돌아가는 버그
- ios디바이스에서만 발생하는 버그로 ios에서는 '더 자세히' 버튼을 누를 경우 페이지 위에(?) 겹처서 detail기사가 출력되고
- 사용자가 스크롤을 내릴 경우 중복되서 겹쳐있던 기사들까지 밑으로 내려가는 버그

# 작업사항
- 웹 쪽에서 '접기' 버튼을 눌렀을 경우 해당 기사로 돌아가는 href를 설정
- 각각의 article에 id 부여 (infiniteScroll.js)
- public/index.js 에서 location.href #기능을 통해 해당 id로 이동

# 참고사항
- 안드로이드에서 정상 동작하는지 확인 필요.

# ref
https://www.computerhope.com/issues/ch000049.htm#opening
